### PR TITLE
add shutdownTimeout option with default to 0

### DIFF
--- a/examples/express-advanced-server.js
+++ b/examples/express-advanced-server.js
@@ -48,10 +48,9 @@ gracefulShutdown(server,
     onShutdown: cleanup,
     forceExit: true,
     shutdownTimeout: 5000,
-    finally: function () {
-      console.log()
+    finally: () => {
       console.log('In "finally" function')
-      console.log('... Server gracefully shutted down.....')
+      console.log('... Server gracefully shut down.....')
     }
   }
 );

--- a/examples/express-advanced-server.js
+++ b/examples/express-advanced-server.js
@@ -47,6 +47,7 @@ gracefulShutdown(server,
     development: false,
     onShutdown: cleanup,
     forceExit: true,
+    shutdownTimeout: 1000,
     finally: function () {
       console.log()
       console.log('In "finally" function')

--- a/examples/express-advanced-server.js
+++ b/examples/express-advanced-server.js
@@ -47,7 +47,7 @@ gracefulShutdown(server,
     development: false,
     onShutdown: cleanup,
     forceExit: true,
-    shutdownTimeout: 1000,
+    shutdownTimeout: 5000,
     finally: function () {
       console.log()
       console.log('In "finally" function')

--- a/examples/express-advanced-server.js
+++ b/examples/express-advanced-server.js
@@ -43,7 +43,7 @@ function cleanup(signal) {
 gracefulShutdown(server,
   {
     signals: 'SIGINT SIGTERM',
-    timeout: 0,
+    timeout: 10000,
     development: false,
     onShutdown: cleanup,
     forceExit: true,

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -14,6 +14,7 @@ declare namespace GracefulShutdown {
     forceExit?: boolean;
     onShutdown?: (signal: string) => Promise<void>;
     finally?: () => void;
+    shutdownTimeout?: number;
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,8 +53,8 @@ function GracefulShutdown(server, opts) {
 
   options.signals.split(' ').forEach(function (signal) {
     if (signal && signal !== '') {
-      process.on(signal, async function () {
-        await shutdown(signal);
+      process.on(signal, function () {
+        shutdown(signal);
       });
     }
   });
@@ -237,17 +237,29 @@ function GracefulShutdown(server, opts) {
         debug('shutting down');
 
         const pollIterations = options.timeout ? Math.round(options.timeout / 250) : 0;
-        // forcefull shutdown after timeout
-        if (options.timeout) {
-          let interation = 0;
-          fnIntervall = setInterval(function () {
-            interation++;
+        exitHandler(waitForShutdownTimeout()).then(() => {
+          // forcefull shutdown after timeout
+          if (options.timeout) {
+            let interation = 0;
+            fnIntervall = setInterval(function () {
+              interation++;
 
-            // test all connections closed already?
-            if (Object.keys(connections).length === 0 && Object.keys(secureConnections).length === 0) {
-              if (options.onShutdown && isFunction(options.onShutdown && !shutdownRun)) {
-                shutdownRun = true;
-                exitHandler(options.onShutdown(sig)).then(() => {
+              // test all connections closed already?
+              if (Object.keys(connections).length === 0 && Object.keys(secureConnections).length === 0) {
+                if (options.onShutdown && isFunction(options.onShutdown && !shutdownRun)) {
+                  shutdownRun = true;
+                  exitHandler(options.onShutdown(sig)).then(() => {
+                    finalHandler();
+
+                    process.nextTick(() => {
+                      resolve();
+                      if (options.forceExit) {
+                        process.exit(1);
+                      }
+                    });
+                  });
+                } else if (!shutdownRun) {
+                  // no onShutdown function
                   finalHandler();
 
                   process.nextTick(() => {
@@ -256,9 +268,16 @@ function GracefulShutdown(server, opts) {
                       process.exit(1);
                     }
                   });
-                });
-              } else if (!shutdownRun) {
-                // no onShutdown function
+                }
+              }
+              if (interation === pollIterations) {
+                // timeout time reached! Now forcefully close all connections
+                debug('Could not close connections in time (' + options.timeout + 'ms), forcefully shutting down');
+
+                // destroy rest of connections
+                destroyAllConnections(true);
+
+                // call finally function (if provided in options)
                 finalHandler();
 
                 process.nextTick(() => {
@@ -268,28 +287,9 @@ function GracefulShutdown(server, opts) {
                   }
                 });
               }
-            }
-            if (interation === pollIterations) {
-              // timeout time reached! Now forcefully close all connections
-              debug('Could not close connections in time (' + options.timeout + 'ms), forcefully shutting down');
+            }, 250);
+          }
 
-              // destroy rest of connections
-              destroyAllConnections(true);
-
-              // call finally function (if provided in options)
-              finalHandler();
-
-              process.nextTick(() => {
-                resolve();
-                if (options.forceExit) {
-                  process.exit(1);
-                }
-              });
-            }
-          }, 250);
-        }
-
-        exitHandler(waitForShutdownTimeout()).then(() => {
           return exitHandler(cleanupHttp()).then(() => {
             if (options.onShutdown && isFunction(options.onShutdown) && !shutdownRun) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -174,29 +174,28 @@ function GracefulShutdown(server, opts) {
   // ----------------------------------
   function shutdown(sig) {
     return new Promise((resolve, reject) => {
+
       function waitForShutdownTimeout() {
         const timeout = options.shutdownTimeout ?? 0;
-        return new Promise((timeoutResolve) => {
+        return new Promise((resolve) => {
           debug(`timeout before cleanup http - ${options.shutdownTimeout}ms`)
-          setTimeout(timeoutResolve, timeout)
+          setTimeout(resolve, timeout)
         })
       }
       function cleanupHttp() {
-        return waitForShutdownTimeout().then(() => {
-          return new Promise((resolve, reject) => {
-              debug('clean up http...')
+        return new Promise((resolve, reject) => {
+            debug('clean up http...')
 
-              destroyAllConnections();
+            destroyAllConnections();
 
-              // normal shutdown / do not allow new connections
-              server.close((err) => {
-                if (err) {
-                  return reject(err);
-                }
-                resolve();
-              });
-          })
-        });
+            // normal shutdown / do not allow new connections
+            server.close((err) => {
+              if (err) {
+                return reject(err);
+              }
+              resolve();
+            });
+        })
       }
 
       debug('shutdown signal - ' + sig);
@@ -290,14 +289,16 @@ function GracefulShutdown(server, opts) {
           }, 250);
         }
 
-        exitHandler(cleanupHttp()).then(() => {
-          if (options.onShutdown && isFunction(options.onShutdown) && !shutdownRun) {
+        exitHandler(waitForShutdownTimeout()).then(() => {
+          return exitHandler(cleanupHttp()).then(() => {
+            if (options.onShutdown && isFunction(options.onShutdown) && !shutdownRun) {
 
-            shutdownRun = true;
-            return exitHandler(options.onShutdown(sig));
-          } else {
-            return;
-          }
+              shutdownRun = true;
+              return exitHandler(options.onShutdown(sig));
+            } else {
+              return;
+            }
+          })
         }).then(finalHandler);
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,8 +53,8 @@ function GracefulShutdown(server, opts) {
 
   options.signals.split(' ').forEach(function (signal) {
     if (signal && signal !== '') {
-      process.on(signal, function () {
-        shutdown(signal);
+      process.on(signal, async function () {
+        await shutdown(signal);
       });
     }
   });
@@ -152,7 +152,6 @@ function GracefulShutdown(server, opts) {
   });
 
   server.on('secureConnection', (socket) => {
-
     if (isShuttingDown) {
       socket.destroy();
     } else {
@@ -173,27 +172,35 @@ function GracefulShutdown(server, opts) {
 
   // shutdown event (per signal)
   // ----------------------------------
-  function shutdown(sig) {
+  async function shutdown(sig) {
 
     return new Promise((resolve, reject) => {
-
-      function cleanupHttp() {
-        return new Promise((resolve, reject) => {
-          if (Boolean(options.shutdownTimeout)) {
-            debug(`timeout before cleanup http - ${options.shutdownTimeout}`)
-          }
-
+      async function waitForShutdownTimeout() {
+        const timeout = options.shutdownTimeout ?? 0;
+        return new Promise((resolve) => {
           setTimeout(() => {
-            debug('clean up http...')
+            if (Boolean(timeout)) {
+              debug(`timeout before cleanup http - ${options.shutdownTimeout}`)
+            }
+            resolve()
+          }, timeout)
+        })
+      }
+      async function cleanupHttp() {
+        return waitForShutdownTimeout().then(() => {
+          new Promise((resolve, reject) => {
+              debug('clean up http...')
 
-            destroyAllConnections();
+              destroyAllConnections();
 
-            // normal shutdown / do not allow new connections
-            server.close((err) => {
-              if (err) { return reject(err); }
-              resolve();
-            });
-          }, options.shutdownTimeout);
+              // normal shutdown / do not allow new connections
+              server.close((err) => {
+                if (err) {
+                  return reject(err);
+                }
+                resolve();
+              });
+          })
         });
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,23 +172,18 @@ function GracefulShutdown(server, opts) {
 
   // shutdown event (per signal)
   // ----------------------------------
-  async function shutdown(sig) {
-
+  function shutdown(sig) {
     return new Promise((resolve, reject) => {
-      async function waitForShutdownTimeout() {
+      function waitForShutdownTimeout() {
         const timeout = options.shutdownTimeout ?? 0;
-        return new Promise((resolve) => {
-          if (Boolean(timeout)) {
-            debug(`timeout before cleanup http - ${options.shutdownTimeout}ms`)
-          }
-          setTimeout(() => {
-            resolve()
-          }, timeout)
+        return new Promise((timeoutResolve) => {
+          debug(`timeout before cleanup http - ${options.shutdownTimeout}ms`)
+          setTimeout(timeoutResolve, timeout)
         })
       }
-      async function cleanupHttp() {
+      function cleanupHttp() {
         return waitForShutdownTimeout().then(() => {
-          new Promise((resolve, reject) => {
+          return new Promise((resolve, reject) => {
               debug('clean up http...')
 
               destroyAllConnections();

--- a/lib/index.js
+++ b/lib/index.js
@@ -178,10 +178,10 @@ function GracefulShutdown(server, opts) {
       async function waitForShutdownTimeout() {
         const timeout = options.shutdownTimeout ?? 0;
         return new Promise((resolve) => {
+          if (Boolean(timeout)) {
+            debug(`timeout before cleanup http - ${options.shutdownTimeout}ms`)
+          }
           setTimeout(() => {
-            if (Boolean(timeout)) {
-              debug(`timeout before cleanup http - ${options.shutdownTimeout}`)
-            }
             resolve()
           }, timeout)
         })

--- a/lib/index.js
+++ b/lib/index.js
@@ -179,7 +179,13 @@ function GracefulShutdown(server, opts) {
 
       function cleanupHttp() {
         return new Promise((resolve, reject) => {
+          if (Boolean(options.shutdownTimeout)) {
+            debug(`timeout before cleanup http - ${options.shutdownTimeout}`)
+          }
+
           setTimeout(() => {
+            debug('clean up http...')
+
             destroyAllConnections();
 
             // normal shutdown / do not allow new connections
@@ -195,7 +201,7 @@ function GracefulShutdown(server, opts) {
 
       // Don't bother with graceful shutdown on development to speed up round trip
       if (options.development) {
-        debug('DEV-Mode - imediate forceful shutdown');
+        debug('DEV-Mode - immediate forceful shutdown');
         return process.exit(0);
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,8 @@ function GracefulShutdown(server, opts) {
     signals: 'SIGINT SIGTERM',
     timeout: 30000,
     development: false,
-    forceExit: true
+    forceExit: true,
+    shutdownTimeout: 0
   }, opts);
 
   let isShuttingDown = false;
@@ -178,13 +179,15 @@ function GracefulShutdown(server, opts) {
 
       function cleanupHttp() {
         return new Promise((resolve, reject) => {
-          destroyAllConnections();
+          setTimeout(() => {
+            destroyAllConnections();
 
-          // normal shutdown / do not allow new connections
-          server.close((err) => {
-            if (err) { return reject(err); }
-            resolve();
-          });
+            // normal shutdown / do not allow new connections
+            server.close((err) => {
+              if (err) { return reject(err); }
+              resolve();
+            });
+          }, options.shutdownTimeout);
         });
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,434 @@
+{
+  "name": "http-graceful-shutdown",
+  "version": "3.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
+    "mime-db": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
+    },
+    "mime-types": {
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
+      "requires": {
+        "mime-db": "1.47.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-graceful-shutdown",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "http-graceful-shutdown",
+  "name": "@calm/http-graceful-shutdown",
   "version": "3.1.0",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calm/http-graceful-shutdown",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calm/http-graceful-shutdown",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/sebhildebrandt/http-graceful-shutdown.git"
+    "url": "https://github.com/calm/http-graceful-shutdown.git"
   },
   "keywords": [
     "http",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calm/http-graceful-shutdown",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json.untracked
+++ b/package.json.untracked
@@ -1,6 +1,6 @@
 {
-  "name": "@calm/http-graceful-shutdown",
-  "version": "3.1.2",
+  "name": "http-graceful-shutdown",
+  "version": "3.1.0",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/calm/http-graceful-shutdown.git"
+    "url": "https://github.com/sebhildebrandt/http-graceful-shutdown.git"
   },
   "keywords": [
     "http",
@@ -37,10 +37,12 @@
   },
   "homepage": "https://github.com/sebhildebrandt/http-graceful-shutdown",
   "dependencies": {
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "express": "^4.17.1"
   },
   "engineStrict": true,
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.0.0",
+    "npm": ">=6.14.11 <7"
   }
 }


### PR DESCRIPTION
## Pull Request


#### Changes proposed:

[enhancement] add option for timeout before initiating shutdown

#### Description (what is this PR about)

There is a kube service that functions like a load balancer between nginx and the express server. When the kube orchestrator tells the express server to shut down, it may take sometime before the same event gets to the upstream kube service. So we want to have an option of some time to allow the upstream kube service to stop sending traffic down to the Express server before initiating server shut down. 


![image](https://user-images.githubusercontent.com/1610182/116949785-0e1f2400-ac38-11eb-868d-317afc85230d.png)

