### PR TITLE
Fix http graceful shutdown

### DIFF
--- a/examples/express-advanced-server.js
+++ b/examples/express-advanced-server.js
@@ -43,7 +43,7 @@ function cleanup(signal) {
 gracefulShutdown(server,
   {
     signals: 'SIGINT SIGTERM',
-    timeout: 5000,
+    timeout: 3000,
     development: false,
     onShutdown: cleanup,
     forceExit: true,

--- a/examples/express-advanced-server.js
+++ b/examples/express-advanced-server.js
@@ -43,7 +43,7 @@ function cleanup(signal) {
 gracefulShutdown(server,
   {
     signals: 'SIGINT SIGTERM',
-    timeout: 0,
+    timeout: 3000,
     development: false,
     onShutdown: cleanup,
     forceExit: true,

--- a/examples/express-advanced-server.js
+++ b/examples/express-advanced-server.js
@@ -43,7 +43,7 @@ function cleanup(signal) {
 gracefulShutdown(server,
   {
     signals: 'SIGINT SIGTERM',
-    timeout: 3000,
+    timeout: 5000,
     development: false,
     onShutdown: cleanup,
     forceExit: true,

--- a/examples/express-advanced-server.js
+++ b/examples/express-advanced-server.js
@@ -43,7 +43,7 @@ function cleanup(signal) {
 gracefulShutdown(server,
   {
     signals: 'SIGINT SIGTERM',
-    timeout: 3000,
+    timeout: 0,
     development: false,
     onShutdown: cleanup,
     forceExit: true,

--- a/examples/express-advanced-server.js
+++ b/examples/express-advanced-server.js
@@ -43,14 +43,14 @@ function cleanup(signal) {
 gracefulShutdown(server,
   {
     signals: 'SIGINT SIGTERM',
-    timeout: 0,
+    timeout: 3000,
     development: false,
     onShutdown: cleanup,
     forceExit: true,
     finally: function () {
       console.log()
       console.log('In "finally" function')
-      console.log('... Server gracefully shutted down.....')
+      console.log('... Server was gracefully shut down.....')
     }
   }
 );

--- a/examples/express-noexit-server.js
+++ b/examples/express-noexit-server.js
@@ -24,7 +24,7 @@ gracefulShutdown(server,
     forceExit: false,             // do not perform process.exit()
     finally: function () {
       console.log()
-      console.log('Server gracefully shutted down.....')
+      console.log('Server gracefully shut down complete')
     }
   }
 );

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,11 +75,9 @@ function GracefulShutdown(server, opts) {
   }
 
   function destroyAllConnections(force = false) {
-
     // destroy empty and idle connections / all connections (if force = true)
-    if (!force) {
-      debug('Destroy Connections : ' + (force ? '2. forced close' : '1. close'));
-    }
+    debug('Destroy Connections : ' + (force ? '2. forced close' : '1. close'));
+
     let counter = 0;
     let secureCounter = 0;
     Object.keys(connections).forEach(function (key) {
@@ -175,6 +173,8 @@ function GracefulShutdown(server, opts) {
     return new Promise((resolve, reject) => {
 
       function cleanupHttp(force = false) {
+        debug(`Clean up http with force = ${force}`);
+
         return new Promise((resolve, reject) => {
           destroyAllConnections(force);
 
@@ -212,11 +212,12 @@ function GracefulShutdown(server, opts) {
       }
 
       // returns true if should force shut down. returns false for shut down without force
-      function isReadyToShutDown (totalNumInterval, intervalTimeout) {
+      function waitForReadyToShutDown (totalNumInterval, intervalTimeout, callback) {
+
         const reachedTimeout = totalNumInterval === 0;
         if (reachedTimeout) {
-          debug('Could not close connections in time (' + options.timeout + 'ms), forcefully shutting down');
-          return true;
+          debug(`Could not close connections in time (${options.timeout}ms), will forcefully shut down`);
+          return callback(true);
         }
 
         // test all connections closed already?
@@ -226,10 +227,12 @@ function GracefulShutdown(server, opts) {
 
         if (allConnectionsClosed) {
           debug('All connections closed. continue to shutting down')
-          return false;
+          return callback(false);
         }
 
-        setTimeout(() => isReadyToShutDown(totalNumInterval--, intervalTimeout), intervalTimeout);
+        setTimeout(
+          () => waitForReadyToShutDown(--totalNumInterval, intervalTimeout, callback),
+          intervalTimeout);
       }
 
       const exitHandler = promise => promise
@@ -246,13 +249,11 @@ function GracefulShutdown(server, opts) {
 
         const pollIterations = options.timeout ? Math.round(options.timeout / 250) : 0;
 
-        let force = options.forceExit
-        if (options.timeout) {
-          force = isReadyToShutDown(pollIterations, 250)
-        }
-        exitHandler(cleanupHttp(force))
-          .then(() => exitHandler(options.onShutdown(sig)))
-          .then(finalHandler);
+        waitForReadyToShutDown(pollIterations, 250, (force) => {
+          exitHandler(cleanupHttp(force))
+            .then(() => exitHandler(options.onShutdown(sig)))
+            .then(finalHandler);
+        })
       }
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,8 +46,6 @@ function GracefulShutdown(server, opts) {
   let secureConnections = {};
   let secureConnectionCounter = 0;
   let failed = false;
-  let shutdownRun = false;
-  let fnInterval;
   let finalRun = false;
 
   options.signals.split(' ').forEach(function (signal) {
@@ -176,14 +174,15 @@ function GracefulShutdown(server, opts) {
 
     return new Promise((resolve, reject) => {
 
-      function cleanupHttp() {
+      function cleanupHttp(force = false) {
         return new Promise((resolve, reject) => {
-          debug('close http server')
+          destroyAllConnections(force);
+
+          debug('Close http server')
           server.close((err) => {
             if (err) {
               return reject(err);
             }
-            destroyAllConnections();
             resolve();
           });
         });
@@ -197,23 +196,41 @@ function GracefulShutdown(server, opts) {
         return process.exit(0);
       }
 
-      const finalHandler = () => {
+      function finalHandler() {
         if (!finalRun) {
           finalRun = true;
           if (options.finally && isFunction(options.finally)) {
             options.finally();
           }
           process.nextTick(() => {
-            if (fnInterval) {
-              fnInterval.unref();
-            }
             if (options.forceExit) {
               process.exit(failed ? 1 : 0);
             }
             resolve();
           });
         }
-      };
+      }
+
+      // returns true if should force shut down. returns false for shut down without force
+      function isReadyToShutDown (totalNumInterval, intervalTimeout) {
+        const reachedTimeout = totalNumInterval === 0;
+        if (reachedTimeout) {
+          debug('Could not close connections in time (' + options.timeout + 'ms), forcefully shutting down');
+          return true;
+        }
+
+        // test all connections closed already?
+        const allConnectionsClosed =
+          Object.keys(connections).length === 0 &&
+          Object.keys(secureConnections).length === 0;
+
+        if (allConnectionsClosed) {
+          debug('All connections closed. continue to shutting down')
+          return false;
+        }
+
+        setTimeout(() => isReadyToShutDown(totalNumInterval--, intervalTimeout), intervalTimeout);
+      }
 
       const exitHandler = promise => promise
         .catch((err) => {
@@ -228,36 +245,14 @@ function GracefulShutdown(server, opts) {
         debug('shutting down');
 
         const pollIterations = options.timeout ? Math.round(options.timeout / 250) : 0;
-        // forceful shutdown after timeout
+
+        let force = options.forceExit
         if (options.timeout) {
-          let iteration = 0;
-          fnInterval = setInterval(function () {
-            iteration++;
-
-            // test all connections closed already?
-            const allConnectionsClosed = Object.keys(connections).length === 0 && Object.keys(secureConnections).length === 0;
-            const reachedTimeout = iteration === pollIterations;
-
-            if (allConnectionsClosed) {
-              debug('All connections closed. continue to shutting down')
-            }
-
-            if (reachedTimeout) {
-              debug('Could not close connections in time (' + options.timeout + 'ms), forcefully shutting down');
-            }
-
-            if (allConnectionsClosed || reachedTimeout) {
-              clearInterval(fnInterval)
-            }
-          }, 250);
+          force = isReadyToShutDown(pollIterations, 250)
         }
-
-        exitHandler(cleanupHttp()).then(() => {
-          if (options.onShutdown && isFunction(options.onShutdown) && !shutdownRun) {
-            shutdownRun = true;
-            return exitHandler(options.onShutdown(sig));
-          }
-        }).then(finalHandler);
+        exitHandler(cleanupHttp(force))
+          .then(() => exitHandler(options.onShutdown(sig)))
+          .then(finalHandler);
       }
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -249,7 +249,7 @@ function GracefulShutdown(server, opts) {
     isShuttingDown = true;
     debug('shutting down');
 
-    return cleanupHttp
+    return cleanupHttp()
       .then(() => {
         const pollIterations = options.timeout
           ? Math.round(options.timeout / 250)

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ function GracefulShutdown(server, opts) {
   let secureConnectionCounter = 0;
   let failed = false;
   let shutdownRun = false;
-  let fnIntervall;
+  let fnInterval;
   let finalRun = false;
 
   options.signals.split(' ').forEach(function (signal) {
@@ -178,11 +178,12 @@ function GracefulShutdown(server, opts) {
 
       function cleanupHttp() {
         return new Promise((resolve, reject) => {
-          destroyAllConnections();
-
-          // normal shutdown / do not allow new connections
+          debug('close http server')
           server.close((err) => {
-            if (err) { return reject(err); }
+            if (err) {
+              return reject(err);
+            }
+            destroyAllConnections();
             resolve();
           });
         });
@@ -192,7 +193,7 @@ function GracefulShutdown(server, opts) {
 
       // Don't bother with graceful shutdown on development to speed up round trip
       if (options.development) {
-        debug('DEV-Mode - imediate forceful shutdown');
+        debug('DEV-Mode - immediate forceful shutdown');
         return process.exit(0);
       }
 
@@ -203,8 +204,8 @@ function GracefulShutdown(server, opts) {
             options.finally();
           }
           process.nextTick(() => {
-            if (fnIntervall) {
-              fnIntervall.unref();
+            if (fnInterval) {
+              fnInterval.unref();
             }
             if (options.forceExit) {
               process.exit(failed ? 1 : 0);
@@ -227,65 +228,34 @@ function GracefulShutdown(server, opts) {
         debug('shutting down');
 
         const pollIterations = options.timeout ? Math.round(options.timeout / 250) : 0;
-        // forcefull shutdown after timeout
+        // forceful shutdown after timeout
         if (options.timeout) {
-          let interation = 0;
-          fnIntervall = setInterval(function () {
-            interation++;
+          let iteration = 0;
+          fnInterval = setInterval(function () {
+            iteration++;
 
             // test all connections closed already?
-            if (Object.keys(connections).length === 0 && Object.keys(secureConnections).length === 0) {
-              if (options.onShutdown && isFunction(options.onShutdown && !shutdownRun)) {
-                shutdownRun = true;
-                exitHandler(options.onShutdown(sig)).then(() => {
-                  finalHandler();
+            const allConnectionsClosed = Object.keys(connections).length === 0 && Object.keys(secureConnections).length === 0;
+            const reachedTimeout = iteration === pollIterations;
 
-                  process.nextTick(() => {
-                    resolve();
-                    if (options.forceExit) {
-                      process.exit(1);
-                    }
-                  });
-                });
-              } else if (!shutdownRun) {
-                // no onShutdown function
-                finalHandler();
-
-                process.nextTick(() => {
-                  resolve();
-                  if (options.forceExit) {
-                    process.exit(1);
-                  }
-                });
-              }
+            if (allConnectionsClosed) {
+              debug('All connections closed. continue to shutting down')
             }
-            if (interation === pollIterations) {
-              // timeout time reached! Now forcefully close all connections
+
+            if (reachedTimeout) {
               debug('Could not close connections in time (' + options.timeout + 'ms), forcefully shutting down');
+            }
 
-              // destroy rest of connections
-              destroyAllConnections(true);
-
-              // call finally function (if provided in options)
-              finalHandler();
-
-              process.nextTick(() => {
-                resolve();
-                if (options.forceExit) {
-                  process.exit(1);
-                }
-              });
+            if (allConnectionsClosed || reachedTimeout) {
+              clearInterval(fnInterval)
             }
           }, 250);
         }
 
         exitHandler(cleanupHttp()).then(() => {
           if (options.onShutdown && isFunction(options.onShutdown) && !shutdownRun) {
-
             shutdownRun = true;
             return exitHandler(options.onShutdown(sig));
-          } else {
-            return;
           }
         }).then(finalHandler);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,16 @@ function GracefulShutdown(server, opts) {
 
   options.signals.split(' ').forEach(function (signal) {
     if (signal && signal !== '') {
-      process.on(signal, () => shutdown(signal));
+      process.on(signal, () => {
+        shutdown(signal)
+          .then(() => {
+            process.exit(failed ? 1 : 0);
+          })
+          .catch((err) => {
+            console.log('server shut down error occurred', err);
+            process.exit(1);
+          })
+      });
     }
   });
 
@@ -199,17 +208,12 @@ function GracefulShutdown(server, opts) {
           if (options.finally && isFunction(options.finally)) {
             options.finally();
           }
-          process.nextTick(() => {
-            if (options.forceExit) {
-              process.exit(failed ? 1 : 0);
-            }
-            resolve();
-          });
         }
       }
 
       // returns true if should force shut down. returns false for shut down without force
       function waitForReadyToShutDown (totalNumInterval, intervalTimeout, callback) {
+        console.log('...... totalNumInterval=', totalNumInterval)
 
         const reachedTimeout = totalNumInterval === 0;
         if (reachedTimeout) {
@@ -244,7 +248,7 @@ function GracefulShutdown(server, opts) {
         isShuttingDown = true;
         debug('shutting down');
 
-        exitHandler(cleanupHttp())
+        return cleanupHttp()
           .then(() => {
             const pollIterations = options.timeout ? Math.round(options.timeout / 250) : 0;
             return waitForReadyToShutDown(
@@ -259,10 +263,16 @@ function GracefulShutdown(server, opts) {
             if (force) {
               destroyAllConnections(force)
             }
-            // call onShutdown()
-            return exitHandler(options.onShutdown(sig))
+
+            return options.onShutdown(sig)
           })
           .then(finalHandler)
+          .catch((err) => {
+            const errString = (typeof err === 'string') ? err : JSON.stringify(err);
+            debug(errString);
+            failed = true;
+            reject(errString);
+          });
       }
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,8 @@ function GracefulShutdown(server, opts) {
     signals: 'SIGINT SIGTERM',
     timeout: 30000,
     development: false,
-    forceExit: true
+    forceExit: true,
+    onShutdown: (signal) => Promise.resolve(signal)
   }, opts);
 
   let isShuttingDown = false;
@@ -50,9 +51,7 @@ function GracefulShutdown(server, opts) {
 
   options.signals.split(' ').forEach(function (signal) {
     if (signal && signal !== '') {
-      process.on(signal, function () {
-        shutdown(signal);
-      });
+      process.on(signal, () => shutdown(signal));
     }
   });
 
@@ -172,11 +171,9 @@ function GracefulShutdown(server, opts) {
 
     return new Promise((resolve, reject) => {
 
-      function cleanupHttp(force = false) {
-        debug(`Clean up http with force = ${force}`);
-
+      function cleanupHttp() {
         return new Promise((resolve, reject) => {
-          destroyAllConnections(force);
+          destroyAllConnections();
 
           debug('Close http server')
           server.close((err) => {
@@ -247,13 +244,25 @@ function GracefulShutdown(server, opts) {
         isShuttingDown = true;
         debug('shutting down');
 
-        const pollIterations = options.timeout ? Math.round(options.timeout / 250) : 0;
-
-        waitForReadyToShutDown(pollIterations, 250, (force) => {
-          exitHandler(cleanupHttp(force))
-            .then(() => exitHandler(options.onShutdown(sig)))
-            .then(finalHandler);
-        })
+        exitHandler(cleanupHttp())
+          .then(() => {
+            const pollIterations = options.timeout ? Math.round(options.timeout / 250) : 0;
+            return waitForReadyToShutDown(
+              pollIterations,
+              250,
+              (force) => Promise.resolve(force)
+            )
+          })
+          .then((force) => {
+            // if after waiting for connections to drain within timeout period
+            // or if timeout has reached, we forcefully disconnect all sockets
+            if (force) {
+              destroyAllConnections(force)
+            }
+            // call onShutdown()
+            return exitHandler(options.onShutdown(sig))
+          })
+          .then(finalHandler)
       }
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,9 +50,7 @@ function GracefulShutdown(server, opts) {
 
   options.signals.split(' ').forEach(function (signal) {
     if (signal && signal !== '') {
-      process.on(signal, function () {
-        shutdown(signal);
-      });
+      process.on(signal, shutdown(signal));
     }
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,10 +8,8 @@
 // gracefully shuts downs http server
 // can be used with http, express, koa, ...
 // =============================================================================
-
 const debug = require('debug')('http-graceful-shutdown');
 const http = require('http');
-
 /**
  * Gracefully shuts down `server` when the process receives
  * the passed signals
@@ -27,19 +25,21 @@ const http = require('http');
  */
 
 function GracefulShutdown(server, opts) {
-
   // option handling
   // ----------------------------------
   opts = opts || {};
 
   // merge opts with default options
-  let options = Object.assign({
-    signals: 'SIGINT SIGTERM',
-    timeout: 30000,
-    development: false,
-    forceExit: true,
-    onShutdown: (signal) => Promise.resolve(signal)
-  }, opts);
+  let options = Object.assign(
+    {
+      signals: 'SIGINT SIGTERM',
+      timeout: 30000,
+      development: false,
+      forceExit: true,
+      onShutdown: (signal) => Promise.resolve(signal),
+    },
+    opts
+  );
 
   let isShuttingDown = false;
   let connections = {};
@@ -52,6 +52,7 @@ function GracefulShutdown(server, opts) {
   options.signals.split(' ').forEach(function (signal) {
     if (signal && signal !== '') {
       process.on(signal, () => {
+        debug('received shut down signal', signal);
         shutdown(signal)
           .then(() => {
             process.exit(failed ? 1 : 0);
@@ -59,7 +60,7 @@ function GracefulShutdown(server, opts) {
           .catch((err) => {
             console.log('server shut down error occurred', err);
             process.exit(1);
-          })
+          });
       });
     }
   });
@@ -155,7 +156,6 @@ function GracefulShutdown(server, opts) {
   });
 
   server.on('secureConnection', (socket) => {
-
     if (isShuttingDown) {
       socket.destroy();
     } else {
@@ -170,111 +170,111 @@ function GracefulShutdown(server, opts) {
     }
   });
 
-  process.on('exit', function () {
+  process.on('close', function () {
     debug('closed');
   });
 
   // shutdown event (per signal)
   // ----------------------------------
   function shutdown(sig) {
+    debug('shutdown signal - ' + sig);
 
-    return new Promise((resolve, reject) => {
+    function cleanupHttp() {
+      destroyAllConnections();
+      debug('Close http server');
 
-      function cleanupHttp() {
-        return new Promise((resolve, reject) => {
-          destroyAllConnections();
-
-          debug('Close http server')
-          server.close((err) => {
-            if (err) {
-              return reject(err);
-            }
-            resolve();
-          });
-        });
-      }
-
-      debug('shutdown signal - ' + sig);
-
-      // Don't bother with graceful shutdown on development to speed up round trip
-      if (options.development) {
-        debug('DEV-Mode - immediate forceful shutdown');
-        return process.exit(0);
-      }
-
-      function finalHandler() {
-        if (!finalRun) {
-          finalRun = true;
-          if (options.finally && isFunction(options.finally)) {
-            options.finally();
+      return new Promise((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            return reject(err);
           }
-        }
-      }
 
-      // returns true if should force shut down. returns false for shut down without force
-      function waitForReadyToShutDown (totalNumInterval, intervalTimeout, callback) {
-        console.log('...... totalNumInterval=', totalNumInterval)
-
-        const reachedTimeout = totalNumInterval === 0;
-        if (reachedTimeout) {
-          debug(`Could not close connections in time (${options.timeout}ms), will forcefully shut down`);
-          return callback(true);
-        }
-
-        // test all connections closed already?
-        const allConnectionsClosed =
-          Object.keys(connections).length === 0 &&
-          Object.keys(secureConnections).length === 0;
-
-        if (allConnectionsClosed) {
-          debug('All connections closed. continue to shutting down')
-          return callback(false);
-        }
-
-        setTimeout(
-          () => waitForReadyToShutDown(--totalNumInterval, intervalTimeout, callback),
-          intervalTimeout);
-      }
-
-      const exitHandler = promise => promise
-        .catch((err) => {
-          const errString = (typeof err === 'string') ? err : JSON.stringify(err);
-          debug(errString);
-          failed = true;
-          reject(errString);
+          return resolve();
         });
+      });
+    }
 
-      if (!isShuttingDown) {
-        isShuttingDown = true;
-        debug('shutting down');
+    // Don't bother with graceful shutdown on development to speed up round trip
+    if (options.development) {
+      debug('DEV-Mode - immediate forceful shutdown');
+      return process.exit(0);
+    }
 
-        return cleanupHttp()
-          .then(() => {
-            const pollIterations = options.timeout ? Math.round(options.timeout / 250) : 0;
-            return waitForReadyToShutDown(
-              pollIterations,
-              250,
-              (force) => Promise.resolve(force)
-            )
-          })
-          .then((force) => {
-            // if after waiting for connections to drain within timeout period
-            // or if timeout has reached, we forcefully disconnect all sockets
-            if (force) {
-              destroyAllConnections(force)
-            }
-
-            return options.onShutdown(sig)
-          })
-          .then(finalHandler)
-          .catch((err) => {
-            const errString = (typeof err === 'string') ? err : JSON.stringify(err);
-            debug(errString);
-            failed = true;
-            reject(errString);
-          });
+    function finalHandler() {
+      if (!finalRun) {
+        finalRun = true;
+        if (options.finally && isFunction(options.finally)) {
+          debug('executing finally()');
+          options.finally();
+        }
       }
-    });
+
+      return Promise.resolve();
+    }
+
+    // returns true if should force shut down. returns false for shut down without force
+    function waitForReadyToShutDown(totalNumInterval) {
+      debug(`waitForReadyToShutDown... totalNumInterval=${totalNumInterval}`);
+
+      const reachedTimeout = totalNumInterval === 0;
+      if (reachedTimeout) {
+        debug(
+          `Could not close connections in time (${options.timeout}ms), will forcefully shut down`
+        );
+        return Promise.resolve(true);
+      }
+
+      // test all connections closed already?
+      const allConnectionsClosed =
+        Object.keys(connections).length === 0 &&
+        Object.keys(secureConnections).length === 0;
+
+      if (allConnectionsClosed) {
+        debug('All connections closed. continue to shutting down');
+        return Promise.resolve(false);
+      }
+
+      debug('schedule the next waitForReadyToShutdown');
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(waitForReadyToShutDown(totalNumInterval - 1));
+        }, 250);
+      });
+    }
+
+    if (isShuttingDown) {
+      return Promise.resolve();
+    }
+
+    isShuttingDown = true;
+    debug('shutting down');
+
+    return cleanupHttp
+      .then(() => {
+        const pollIterations = options.timeout
+          ? Math.round(options.timeout / 250)
+          : 0;
+
+        return waitForReadyToShutDown(pollIterations);
+      })
+      .then((force) => {
+        debug('do onShutdown now');
+
+        // if after waiting for connections to drain within timeout period
+        // or if timeout has reached, we forcefully disconnect all sockets
+        if (force) {
+          destroyAllConnections(force);
+        }
+
+        return options.onShutdown(sig);
+      })
+      .then(finalHandler)
+      .catch((err) => {
+        const errString = typeof err === 'string' ? err : JSON.stringify(err);
+        debug(errString);
+        failed = true;
+        throw errString;
+      });
   }
 
   function shutdownManual() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,7 @@ function GracefulShutdown(server, opts) {
 
     // destroy empty and idle connections / all connections (if force = true)
     if (!force) {
-      debug('Destroy Connections : ' + force ? '2. forced close' : '1. close');
+      debug('Destroy Connections : ' + (force ? '2. forced close' : '1. close'));
     }
     let counter = 0;
     let secureCounter = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calm/http-graceful-shutdown",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calm/http-graceful-shutdown",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "http-graceful-shutdown",
-  "version": "3.0.2",
+  "name": "@calm/http-graceful-shutdown",
+  "version": "3.1.7",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calm/http-graceful-shutdown",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calm/http-graceful-shutdown",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "gracefully shuts downs http server",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## [PI-448]

I forked `sebhildebrandt/http-graceful-shutdown` and learned that there are a couple of behaviors of the library that doesn't support our use case very well. 

1. `onShutdown()` is called immediately after shut down starts. This is also where we want to do cleanup operations. While there are open connections to the express server, we actually want to delay this call until later. The fix is to delay this until timeout or connections have all been closed.
2. The logic for wait until the timeout has reached or when open connections have all closed was challenging to follow with `setInterval()`. Instead I've made this into a recursive function which recurses and setTimeout for a time interval to check on the status of either all connections are closed or the timeout has reached. 


The shutdown flow is as follows: 
1. set `isShuttingDown=true`
2. `destroyAllConnections()`: sets `connection: close` headers on all existing requests
3. `server.close()` so that the server stops receiving requests 
4. `waitForReadyToShutDown()`: poll on an interval to check if all connections have finished or `timeout` has reached. Returns true if the timeout has reached. 
5. If the `timeout` has reached without all connections closed, then call `destroyAllConnections(true)` to force all socked to close. 
6. exec `onShutdown()` (this is where we pass in the cleanup operation) 
7. exec `finally` 

[PI-448]: https://calmdotcom.atlassian.net/browse/PI-448